### PR TITLE
[fix] remove redundant request_params in ollama chat

### DIFF
--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -98,7 +98,6 @@ class Ollama(Model):
             "format": self.format,
             "options": self.options,
             "keep_alive": self.keep_alive,
-            "request_params": self.request_params,
         }
         # Filter out None values
         request_params = {k: v for k, v in base_params.items() if v is not None}


### PR DESCRIPTION
## Summary
- fix duplication of request_params in `ollama.chat.get_request_kwargs`

## Testing
- `./scripts/format.sh`
- `./scripts/validate.sh`
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_b_683fb7aa853c832fb29b903e6bff90f7